### PR TITLE
docs: update scripting file paths

### DIFF
--- a/api/client/audio.md
+++ b/api/client/audio.md
@@ -9,7 +9,7 @@ function audio.play(file) end
 Plays a sound.
 
 #### Parameters
-- `file`: string: The file path relative to the Flarial folder.
+- `file`: string: The file path relative to the Flarial client data folder.
 #### Returns
 - nil:
 

--- a/api/misc/fs.md
+++ b/api/misc/fs.md
@@ -9,7 +9,7 @@ function fs.exists(path) end
 Checks if the specified path exists.
 
 #### Parameters
-- `path`: string: The file path relative to the Flarial folder.
+- `path`: string: The file path relative to the Flarial client data folder.
 #### Returns
 - boolean: True if the path exists.
 
@@ -20,7 +20,7 @@ function fs.isDirectory(path) end
 Checks if the specified path is a directory.
 
 #### Parameters
-- `path`: string: The file path relative to the Flarial folder.
+- `path`: string: The file path relative to the Flarial client data folder.
 #### Returns
 - boolean: True if the path is a directory.
 
@@ -31,7 +31,7 @@ function fs.create(path) end
 Creates a directory at the specified path.
 
 #### Parameters
-- `path`: string: The directory path relative to the Flarial folder.
+- `path`: string: The directory path relative to the Flarial client data folder.
 #### Returns
 - boolean: True if the directory was successfully created.
 
@@ -42,7 +42,7 @@ function fs.remove(path) end
 Removes the file or directory at the specified path.
 
 #### Parameters
-- `path`: string: The file or directory path relative to the Flarial folder.
+- `path`: string: The file or directory path relative to the Flarial client data folder.
 #### Returns
 - boolean: True if removal was successful.
 
@@ -53,7 +53,7 @@ function fs.readFile(path) end
 Reads the contents of a file at the specified path.
 
 #### Parameters
-- `path`: string: The file path relative to the Flarial folder.
+- `path`: string: The file path relative to the Flarial client data folder.
 #### Returns
 - string: The file’s content.
 
@@ -64,7 +64,7 @@ function fs.writeFile(path, content) end
 Writes content to the file at the specified path.
 
 #### Parameters
-- `path`: string: The file path relative to the Flarial folder.
+- `path`: string: The file path relative to the Flarial client data folder.
 - `content`: string: The content to write.
 #### Returns
 - boolean: True if writing was successful.
@@ -76,7 +76,7 @@ function fs.listDirectory(path) end
 Lists the contents of the directory at the specified path.
 
 #### Parameters
-- `path`: string: The directory path relative to the Flarial folder.
+- `path`: string: The directory path relative to the Flarial client data folder.
 #### Returns
 - string[]: An array of file and directory names.
 

--- a/autocomplete/client/audio.lua
+++ b/autocomplete/client/audio.lua
@@ -3,7 +3,7 @@
 ---@class audio
 audio = {}
 
----Plays a sound.  
----@param file string The file path relative to the Flarial folder.  
----@return nil  
+---Plays a sound.
+---@param file string The file path relative to the Flarial client data folder.
+---@return nil
 function audio.play(file) end

--- a/autocomplete/misc/fs.lua
+++ b/autocomplete/misc/fs.lua
@@ -3,38 +3,38 @@
 ---@class fs
 fs = {}
 
----Checks if the specified path exists.  
----@param path string The file path relative to the Flarial folder.  
----@return boolean True if the path exists.  
+---Checks if the specified path exists.
+---@param path string The file path relative to the Flarial client data folder.
+---@return boolean True if the path exists.
 function fs.exists(path) end
 
----Checks if the specified path is a directory.  
----@param path string The file path relative to the Flarial folder.  
----@return boolean True if the path is a directory.  
+---Checks if the specified path is a directory.
+---@param path string The file path relative to the Flarial client data folder.
+---@return boolean True if the path is a directory.
 function fs.isDirectory(path) end
 
----Creates a directory at the specified path.  
----@param path string The directory path relative to the Flarial folder.  
----@return boolean True if the directory was successfully created.  
+---Creates a directory at the specified path.
+---@param path string The directory path relative to the Flarial client data folder.
+---@return boolean True if the directory was successfully created.
 function fs.create(path) end
 
----Removes the file or directory at the specified path.  
----@param path string The file or directory path relative to the Flarial folder.  
----@return boolean True if removal was successful.  
+---Removes the file or directory at the specified path.
+---@param path string The file or directory path relative to the Flarial client data folder.
+---@return boolean True if removal was successful.
 function fs.remove(path) end
 
----Reads the contents of a file at the specified path.  
----@param path string The file path relative to the Flarial folder.  
----@return string The file’s content.  
+---Reads the contents of a file at the specified path.
+---@param path string The file path relative to the Flarial client data folder.
+---@return string The file’s content.
 function fs.readFile(path) end
 
----Writes content to the file at the specified path.  
----@param path string The file path relative to the Flarial folder.  
----@param content string The content to write.  
----@return boolean True if writing was successful.  
+---Writes content to the file at the specified path.
+---@param path string The file path relative to the Flarial client data folder.
+---@param content string The content to write.
+---@return boolean True if writing was successful.
 function fs.writeFile(path, content) end
 
----Lists the contents of the directory at the specified path.  
----@param path string The directory path relative to the Flarial folder.  
----@return string[] An array of file and directory names.  
+---Lists the contents of the directory at the specified path.
+---@param path string The directory path relative to the Flarial client data folder.
+---@return string[] An array of file and directory names.
 function fs.listDirectory(path) end

--- a/getting-started/first_script.md
+++ b/getting-started/first_script.md
@@ -3,9 +3,11 @@
 To get started, let's create a simple module script.
 
 ### Step 1: Navigate to the Modules Directory
-Create your script inside the following directory:
+Inject Flarial and run `.path scripts` in chat to open the Scripts folder, then open the `Modules` folder.
+
+On current Windows/GDK builds, the modules directory is:
 ```
-%localappdata%\Packages\Microsoft.MinecraftUWP_8wekyb3d8bbwe\RoamingState\Flarial\Scripts\Modules
+%LOCALAPPDATA%\Flarial\Client\Scripts\Modules
 ```
 
 ### Step 2: Create a New Lua File

--- a/getting-started/prerequisites.md
+++ b/getting-started/prerequisites.md
@@ -15,11 +15,16 @@ To enable autocompletion for Flarial, follow these steps:
 3. Search for **User Third Party** (this setting is located near the bottom).
 4. Add the following directory path:
    ```
-   %localappdata%\Packages\Microsoft.MinecraftUWP_8wekyb3d8bbwe\RoamingState\Flarial\Scripts\AutoComplete
+   %LOCALAPPDATA%\Flarial\Client\Scripts\AutoComplete
    ```
 5. Save your settings.
 
 ### Important Note
-For autocompletion to work correctly, ensure that you open the entire **Scripts** folder in Visual Studio Code rather than just an individual script file.
+For autocompletion to work correctly, open the entire current Scripts folder in Visual Studio Code:
+```
+%LOCALAPPDATA%\Flarial\Client\Scripts
+```
+
+If you are on an old UWP build, the legacy path was `%LOCALAPPDATA%\Packages\Microsoft.MinecraftUWP_8wekyb3d8bbwe\RoamingState\Flarial\Scripts`, but current GDK builds use `%LOCALAPPDATA%\Flarial\Client\Scripts`.
 
 With these steps completed, you’ll have full access to all Flarial functions through autocompletion, making scripting way easier!

--- a/index.md
+++ b/index.md
@@ -7,15 +7,24 @@ Flarial Scripting is an API that allows you to create custom modules and command
 ## Script Locations
 To keep everything organized, Flarial stores scripts in designated folders based on their type.
 
-Modules can be found here:
+The easiest way to open the correct folder is to inject Flarial and run `.path scripts` in chat.
+
+Current Windows/GDK builds use this client data folder:
 ```
-%localappdata%\Packages\Microsoft.MinecraftUWP_8wekyb3d8bbwe\RoamingState\Flarial\Scripts\Modules
+%LOCALAPPDATA%\Flarial\Client
 ```
 
-Commands can be found here:
+Modules go here:
 ```
-%localappdata%\Packages\Microsoft.MinecraftUWP_8wekyb3d8bbwe\RoamingState\Flarial\Scripts\Commands
+%LOCALAPPDATA%\Flarial\Client\Scripts\Modules
 ```
+
+Commands go here:
+```
+%LOCALAPPDATA%\Flarial\Client\Scripts\Commands
+```
+
+Legacy UWP builds used `%LOCALAPPDATA%\Packages\Microsoft.MinecraftUWP_8wekyb3d8bbwe\RoamingState\Flarial`. If you still have that folder, Flarial migrates its data into the current client folder on GDK builds.
 
 ## Where do I find community made scripts?
 You can find and download verified scripts from the [Flarial Marketplace](https://marketplace.flarial.xyz). All scripts in the marketplace have been reviewed and verified by the Flarial team to ensure they are safe and free from malicious code.


### PR DESCRIPTION
## Summary
- update scripting docs from the old UWP `Microsoft.MinecraftUWP...RoamingState` paths to the current `%LOCALAPPDATA%\Flarial\Client\Scripts` paths
- document module, command, autocomplete, and Scripts folder locations
- clarify that fs/audio paths are relative to the Flarial client data folder
- keep a legacy UWP note for users with older installs

## Validation
- `git diff --check`
- `npm run build`
