### PR TITLE
docs: refresh scripting API reference

### DIFF
--- a/api/client/audio.md
+++ b/api/client/audio.md
@@ -7,10 +7,11 @@
 function audio.play(file) end
 ```
 Plays a sound.
+Returns false if the file does not exist.
 
 #### Parameters
 - `file`: string: The file path relative to the Flarial client data folder.
 #### Returns
-- nil:
+- boolean: True if playback was requested, false if the file was missing.
 
 Reference: [audio.lua](https://github.com/flarialmc/scripting-wiki/tree/main/autocomplete/client/audio.lua)

--- a/api/game/world.md
+++ b/api/game/world.md
@@ -30,6 +30,33 @@ Returns 0 if the block source isn't available.
 #### Returns
 - number: The light level.
 
+## `world.raycast`
+```lua
+function world.raycast(maxDistance) end
+```
+Raycasts from the player's crosshair and returns the hit block if it is within range.
+Returns nil if there is no local player, no level, the max distance is invalid, or no tile was hit within range.
+
+#### Parameters
+- `maxDistance`: number|nil: Maximum hit distance. Defaults to 6.
+#### Returns
+- table|nil: Hit info with x, y, z, blockX, blockY, blockZ, face, faceId, and distance.
+
+## `world.worldToScreen`
+```lua
+function world.worldToScreen(x, y, z) end
+```
+Projects a world position to screen coordinates.
+
+#### Parameters
+- `x`: number: The world x coordinate.
+- `y`: number: The world y coordinate.
+- `z`: number: The world z coordinate.
+#### Returns
+- boolean: visible True if the world position is visible on screen.
+- number: screenX The projected screen x coordinate.
+- number: screenY The projected screen y coordinate.
+
 ## `world.getDimension`
 ```lua
 function world.getDimension() end

--- a/api/imgui/imgui.md
+++ b/api/imgui/imgui.md
@@ -12,7 +12,7 @@ Begins a new ImGui window.
 #### Parameters
 - `name`: string: The window name.
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.End`
 ```lua
@@ -21,7 +21,7 @@ function ImGui.End() end
 Ends the current ImGui window.
 
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.BeginChild`
 ```lua
@@ -35,7 +35,7 @@ Begins a child window.
 - `child_flags`: boolean|nil: ImGuiChildFlags.
 - `window_flags`: number|nil: ImGuiWindowFlags.
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.BeginChildID`
 ```lua
@@ -49,7 +49,7 @@ Begins a child window using an ID.
 - `child_flags`: number|nil: ImGuiChildFlags.
 - `window_flags`: number|nil: ImGuiWindowFlags.
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.BeginChildFrame`
 ```lua
@@ -62,7 +62,7 @@ Begins a child frame.
 - `size`: table: The size of the frame, in pixels. Format: {width, height}
 - `flags`: number|nil: ImGuiWindowFlags.
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.BeginCombo`
 ```lua
@@ -104,7 +104,7 @@ function ImGui.BeginGroup() end
 Begins an ImGui group.
 
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.BeginMainMenuBar`
 ```lua
@@ -127,11 +127,11 @@ Begins a menu.
 #### Returns
 - boolean: True if the menu is open.
 
-## `ImGui.BeginMainMenuBar`
+## `ImGui.BeginMenuBar`
 ```lua
-function ImGui.BeginMainMenuBar() end
+function ImGui.BeginMenuBar() end
 ```
-Begins a main menu bar.
+Begins a menu bar inside the current window.
 
 #### Returns
 - boolean: True if the menu bar is open.
@@ -205,7 +205,7 @@ function ImGui.BeginTooltip() end
 Begins a tooltip.
 
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.Bullet`
 ```lua
@@ -214,7 +214,7 @@ function ImGui.Bullet() end
 Displays a bullet point.
 
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.BulletText`
 ```lua
@@ -225,7 +225,7 @@ Displays bullet text.
 #### Parameters
 - `text`: string: The text to display.
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.Button`
 ```lua
@@ -246,7 +246,7 @@ function ImGui.CloseCurrentPopup() end
 Closes the current popup.
 
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.CollapsingHeader`
 ```lua
@@ -282,7 +282,7 @@ Displays text.
 #### Parameters
 - `text`: string: The text to display.
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.InputText`
 ```lua
@@ -333,7 +333,16 @@ Continues drawing on the same line instead of moving to a new line.
 - `offset`: number|nil: X offset from the start of the line in pixels. Use `0` to place immediately after the previous widget.
 - `spacing`: number|nil: Spacing between the previous item and the new item in pixels. Use `-1` for default spacing.
 #### Returns
-- nil: 
+- nil:
+
+## `ImGui.GetIO`
+```lua
+function ImGui.GetIO() end
+```
+Gets ImGui IO state.
+
+#### Returns
+- any: The ImGui IO object.
 
 ## `ImGui.GetDrawData`
 ```lua
@@ -354,7 +363,7 @@ Sets the next window size.
 - `size`: table: The size of the next window, in pixels. Format: {width, height}
 - `flags`: number|nil: ImGuiCond.
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.SetNextWindowPos`
 ```lua
@@ -366,7 +375,7 @@ Sets the next window position.
 - `pos`: table: The position of the new window, in pixels. Format: {width, height}
 - `pivot`: table|nil: The pivot of the new window, in pixels. Format: {width, height}
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.SetNextWindowBgAlpha`
 ```lua
@@ -377,7 +386,7 @@ Sets the next window background alpha.
 #### Parameters
 - `alpha`: number: The background alpha value.
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.SetNextWindowCollapsed`
 ```lua
@@ -388,7 +397,7 @@ Sets whether the next window is collapsed.
 #### Parameters
 - `collapsed`: boolean: The collapsed state.
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.SetNextWindowFocus`
 ```lua
@@ -397,7 +406,7 @@ function ImGui.SetNextWindowFocus() end
 Sets focus to the next window.
 
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.SetNextWindowContentSize`
 ```lua
@@ -408,7 +417,7 @@ Sets the next window content size.
 #### Parameters
 - `size`: table: The size of the next content, in pixels. Format: {width, height}
 #### Returns
-- nil: 
+- nil:
 
 ## `ImGui.IsKeyDown`
 ```lua
@@ -518,9 +527,9 @@ Returns the size of the Minecraft window.
 #### Returns
 - Vector2: the width and height of the window in pixels.
 
-## `ImGui.GetFrameRate`
+## `ImGui.GetFramerate`
 ```lua
-function ImGui.GetFrameRate() end
+function ImGui.GetFramerate() end
 ```
 Returns Minecraft's framerate in floating point numbers.
 

--- a/autocomplete/client/audio.lua
+++ b/autocomplete/client/audio.lua
@@ -4,6 +4,7 @@
 audio = {}
 
 ---Plays a sound.
+---Returns false if the file does not exist.
 ---@param file string The file path relative to the Flarial client data folder.
----@return nil
+---@return boolean True if playback was requested, false if the file was missing.
 function audio.play(file) end

--- a/autocomplete/game/world.lua
+++ b/autocomplete/game/world.lua
@@ -19,6 +19,21 @@ function world.getBlock(x, y, z) end
 ---@return number The light level.
 function world.getLightLevel(x, y, z) end
 
+---Raycasts from the player's crosshair and returns the hit block if it is within range.
+---Returns nil if there is no local player, no level, the max distance is invalid, or no tile was hit within range.
+---@param maxDistance number|nil Maximum hit distance. Defaults to 6.
+---@return table|nil Hit info with x, y, z, blockX, blockY, blockZ, face, faceId, and distance.
+function world.raycast(maxDistance) end
+
+---Projects a world position to screen coordinates.
+---@param x number The world x coordinate.
+---@param y number The world y coordinate.
+---@param z number The world z coordinate.
+---@return boolean visible True if the world position is visible on screen.
+---@return number screenX The projected screen x coordinate.
+---@return number screenY The projected screen y coordinate.
+function world.worldToScreen(x, y, z) end
+
 ---Returns the current dimension name.
 ---Returns "unknown" if the dimension isn't available.
 ---@return string The dimension name.

--- a/autocomplete/imgui/imgui.lua
+++ b/autocomplete/imgui/imgui.lua
@@ -4,258 +4,262 @@
 ---@class ImGui
 ImGui = {}
 
----Begins a new ImGui window.  
----@param name string The window name.  
----@return nil  
+---Begins a new ImGui window.
+---@param name string The window name.
+---@return nil
 function ImGui.Begin(name) end
 
----Ends the current ImGui window.  
----@return nil  
+---Ends the current ImGui window.
+---@return nil
 function ImGui.End() end
 
----Begins a child window.  
----@param name string The child window name.  
----@param size table The size of the child window, in pixels. Format: {width, height}  
----@param child_flags boolean|nil ImGuiChildFlags.  
----@param window_flags number|nil ImGuiWindowFlags.  
----@return nil  
+---Begins a child window.
+---@param name string The child window name.
+---@param size table The size of the child window, in pixels. Format: {width, height}
+---@param child_flags boolean|nil ImGuiChildFlags.
+---@param window_flags number|nil ImGuiWindowFlags.
+---@return nil
 function ImGui.BeginChild(name, size, child_flags, window_flags) end
 
----Begins a child window using an ID.  
----@param id number The ImGui ID.  
----@param size table The size of the child window, in pixels. Format: {width, height}  
----@param child_flags number|nil ImGuiChildFlags.  
----@param window_flags number|nil ImGuiWindowFlags.  
----@return nil  
+---Begins a child window using an ID.
+---@param id number The ImGui ID.
+---@param size table The size of the child window, in pixels. Format: {width, height}
+---@param child_flags number|nil ImGuiChildFlags.
+---@param window_flags number|nil ImGuiWindowFlags.
+---@return nil
 function ImGui.BeginChildID(id, size, child_flags, window_flags) end
 
----Begins a child frame.  
----@param id number The ImGui ID.  
----@param size table The size of the frame, in pixels. Format: {width, height}  
----@param flags number|nil ImGuiWindowFlags.  
----@return nil  
+---Begins a child frame.
+---@param id number The ImGui ID.
+---@param size table The size of the frame, in pixels. Format: {width, height}
+---@param flags number|nil ImGuiWindowFlags.
+---@return nil
 function ImGui.BeginChildFrame(id, size, flags) end
 
----Begins a combo box.  
----@param name string The combo box name.  
----@param previewValue string The preview value to display.  
----@param flags number|nil ImGuiComboFlags.  
----@return boolean True if the combo box is open.  
+---Begins a combo box.
+---@param name string The combo box name.
+---@param previewValue string The preview value to display.
+---@param flags number|nil ImGuiComboFlags.
+---@return boolean True if the combo box is open.
 function ImGui.BeginCombo(name, previewValue, flags) end
 
----Begins a drag and drop source.  
----@param flags number|nil ImGuiDragDropFlags.  
----@return boolean True if the drag and drop source has begun.  
+---Begins a drag and drop source.
+---@param flags number|nil ImGuiDragDropFlags.
+---@return boolean True if the drag and drop source has begun.
 function ImGui.BeginDragDropSource(flags) end
 
----Begins a drag and drop target.  
----@return boolean True if a drag and drop target is available.  
+---Begins a drag and drop target.
+---@return boolean True if a drag and drop target is available.
 function ImGui.BeginDragDropTarget() end
 
----Begins an ImGui group.  
----@return nil  
+---Begins an ImGui group.
+---@return nil
 function ImGui.BeginGroup() end
 
----Begins the main menu bar.  
----@return boolean True if the main menu bar is active.  
+---Begins the main menu bar.
+---@return boolean True if the main menu bar is active.
 function ImGui.BeginMainMenuBar() end
 
----Begins a menu.  
----@param name string The menu name.  
----@param enabled boolean|nil Whether the menu is enabled.  
----@return boolean True if the menu is open.  
+---Begins a menu.
+---@param name string The menu name.
+---@param enabled boolean|nil Whether the menu is enabled.
+---@return boolean True if the menu is open.
 function ImGui.BeginMenu(name, enabled) end
 
----Begins a main menu bar.  
----@return boolean True if the menu bar is open.  
-function ImGui.BeginMainMenuBar() end
+---Begins a menu bar inside the current window.
+---@return boolean True if the menu bar is open.
+function ImGui.BeginMenuBar() end
 
----Begins a popup window.  
----@param name string The popup window name.  
----@param flags number|nil ImGuiWindowFlags.  
----@return boolean True if the popup began.  
+---Begins a popup window.
+---@param name string The popup window name.
+---@param flags number|nil ImGuiWindowFlags.
+---@return boolean True if the popup began.
 function ImGui.BeginPopup(name, flags) end
 
----Begins a context popup for an item.  
----@param name string|nil The context popup name.  
----@param flags number|nil ImGuiPopupFlags.  
----@return boolean True if the context popup began.  
+---Begins a context popup for an item.
+---@param name string|nil The context popup name.
+---@param flags number|nil ImGuiPopupFlags.
+---@return boolean True if the context popup began.
 function ImGui.BeginPopupContextItem(name, flags) end
 
----Begins a context popup for a void area.  
----@param name string|nil The context popup name.  
----@param flags number|nil ImGuiPopupFlags.  
----@return boolean True if the context popup began.  
+---Begins a context popup for a void area.
+---@param name string|nil The context popup name.
+---@param flags number|nil ImGuiPopupFlags.
+---@return boolean True if the context popup began.
 function ImGui.BeginPopupContextVoid(name, flags) end
 
----Begins a tab bar.  
----@param name string The tab bar name.  
----@param flags number|nil ImGuiTabBarFlags.  
----@return boolean True if the tab bar began.  
+---Begins a tab bar.
+---@param name string The tab bar name.
+---@param flags number|nil ImGuiTabBarFlags.
+---@return boolean True if the tab bar began.
 function ImGui.BeginTabBar(name, flags) end
 
----Begins a table.  
----@param name string The table name.  
----@param column number Number of columns.  
----@param outer_size table The outer size, in pixels. Format: {width, height}  
----@param inner_width number|nil The inner width.  
----@return boolean True if the table began.  
+---Begins a table.
+---@param name string The table name.
+---@param column number Number of columns.
+---@param outer_size table The outer size, in pixels. Format: {width, height}
+---@param inner_width number|nil The inner width.
+---@return boolean True if the table began.
 function ImGui.BeginTable(name, column, outer_size, inner_width) end
 
----Begins a tooltip.  
----@return nil  
+---Begins a tooltip.
+---@return nil
 function ImGui.BeginTooltip() end
 
----Displays a bullet point.  
----@return nil  
+---Displays a bullet point.
+---@return nil
 function ImGui.Bullet() end
 
----Displays bullet text.  
----@param text string The text to display.  
----@return nil  
+---Displays bullet text.
+---@param text string The text to display.
+---@return nil
 function ImGui.BulletText(text) end
 
----Creates a button.  
----@param label string The button label.  
----@param size table|nil The size of the button, in pixels. Format: {width, height}  
----@return boolean True if the button was pressed.  
+---Creates a button.
+---@param label string The button label.
+---@param size table|nil The size of the button, in pixels. Format: {width, height}
+---@return boolean True if the button was pressed.
 function ImGui.Button(label, size) end
 
----Closes the current popup.  
----@return nil  
+---Closes the current popup.
+---@return nil
 function ImGui.CloseCurrentPopup() end
 
----Creates a collapsing header.  
----@param label string The header label.  
----@param flags number|nil ImGuiTreeNodeFlags.  
----@return boolean True if the header is open.  
+---Creates a collapsing header.
+---@param label string The header label.
+---@param flags number|nil ImGuiTreeNodeFlags.
+---@return boolean True if the header is open.
 function ImGui.CollapsingHeader(label, flags) end
 
----Creates a color button.  
----@param desc_id string The description ID.  
----@param color table The color of the button, in RGBA. Format: {red, green, blue, alpha}  
----@param size table|nil The size of the button, in pixels. Format: {width, height}  
----@return boolean True if the color button was pressed.  
+---Creates a color button.
+---@param desc_id string The description ID.
+---@param color table The color of the button, in RGBA. Format: {red, green, blue, alpha}
+---@param size table|nil The size of the button, in pixels. Format: {width, height}
+---@return boolean True if the color button was pressed.
 function ImGui.ColorButton(desc_id, color, size) end
 
----Displays text.  
----@param text string The text to display.  
----@return nil  
+---Displays text.
+---@param text string The text to display.
+---@return nil
 function ImGui.Text(text) end
 
----Creates an editable text input field.  
----@param label string The label for the text input field.  
----@param text string The current text (mutable reference recommended).  
----@return string The updated text after user input.  
+---Creates an editable text input field.
+---@param label string The label for the text input field.
+---@param text string The current text (mutable reference recommended).
+---@return string The updated text after user input.
 function ImGui.InputText(label, text) end
 
----Gets the background draw list.  
----@return ImDrawList The background draw list.  
+---Gets the background draw list.
+---@return ImDrawList The background draw list.
 function ImGui.GetBackgroundDrawList() end
 
----Gets the foreground draw list.  
----@return ImDrawList The foreground draw list.  
+---Gets the foreground draw list.
+---@return ImDrawList The foreground draw list.
 function ImGui.GetForegroundDrawList() end
 
----Gets the window draw list.  
----@return ImDrawList The window draw list.  
+---Gets the window draw list.
+---@return ImDrawList The window draw list.
 function ImGui.GetWindowDrawList() end
 
----Continues drawing on the same line instead of moving to a new line.  
----@param offset number|nil X offset from the start of the line in pixels. Use `0` to place immediately after the previous widget.  
----@param spacing number|nil Spacing between the previous item and the new item in pixels. Use `-1` for default spacing.  
----@return nil  
+---Continues drawing on the same line instead of moving to a new line.
+---@param offset number|nil X offset from the start of the line in pixels. Use `0` to place immediately after the previous widget.
+---@param spacing number|nil Spacing between the previous item and the new item in pixels. Use `-1` for default spacing.
+---@return nil
 function ImGui.SameLine(offset, spacing) end
 
----Gets the current draw data.  
----@return any The draw data.  
+---Gets ImGui IO state.
+---@return any The ImGui IO object.
+function ImGui.GetIO() end
+
+---Gets the current draw data.
+---@return any The draw data.
 function ImGui.GetDrawData() end
 
----Sets the next window size.  
----@param size table The size of the next window, in pixels. Format: {width, height}  
----@param flags number|nil ImGuiCond.  
----@return nil  
+---Sets the next window size.
+---@param size table The size of the next window, in pixels. Format: {width, height}
+---@param flags number|nil ImGuiCond.
+---@return nil
 function ImGui.SetNextWindowSize(size, flags) end
 
----Sets the next window position.  
----@param pos table The position of the new window, in pixels. Format: {width, height}  
----@param pivot table|nil The pivot of the new window, in pixels. Format: {width, height}  
----@return nil  
+---Sets the next window position.
+---@param pos table The position of the new window, in pixels. Format: {width, height}
+---@param pivot table|nil The pivot of the new window, in pixels. Format: {width, height}
+---@return nil
 function ImGui.SetNextWindowPos(pos, pivot) end
 
----Sets the next window background alpha.  
----@param alpha number The background alpha value.  
----@return nil  
+---Sets the next window background alpha.
+---@param alpha number The background alpha value.
+---@return nil
 function ImGui.SetNextWindowBgAlpha(alpha) end
 
----Sets whether the next window is collapsed.  
----@param collapsed boolean The collapsed state.  
----@return nil  
+---Sets whether the next window is collapsed.
+---@param collapsed boolean The collapsed state.
+---@return nil
 function ImGui.SetNextWindowCollapsed(collapsed) end
 
----Sets focus to the next window.  
----@return nil  
+---Sets focus to the next window.
+---@return nil
 function ImGui.SetNextWindowFocus() end
 
----Sets the next window content size.  
----@param size table The size of the next content, in pixels. Format: {width, height}  
----@return nil  
+---Sets the next window content size.
+---@param size table The size of the next content, in pixels. Format: {width, height}
+---@return nil
 function ImGui.SetNextWindowContentSize(size) end
 
----Checks if a key is down.  
----@param key number The key code.  
----@return boolean True if the key is down.  
+---Checks if a key is down.
+---@param key number The key code.
+---@return boolean True if the key is down.
 function ImGui.IsKeyDown(key) end
 
----Checks if a key is pressed.  
----@param key number The key code.  
----@param key_repeat boolean If the key should repeat.  
----@return boolean True if the key is pressed.  
+---Checks if a key is pressed.
+---@param key number The key code.
+---@param key_repeat boolean If the key should repeat.
+---@return boolean True if the key is pressed.
 function ImGui.IsKeyPressed(key, key_repeat) end
 
----Checks if a key is pressed.  
----@param key number The key code.  
----@return boolean True if the key is pressed.  
+---Checks if a key is pressed.
+---@param key number The key code.
+---@return boolean True if the key is pressed.
 function ImGui.IsKeyPressed(key) end
 
----Checks if a key is released.  
----@param key number The key code.  
----@return boolean True if the key is released.  
+---Checks if a key is released.
+---@param key number The key code.
+---@return boolean True if the key is released.
 function ImGui.IsKeyReleased(key) end
 
----Checks if a mouse button is down.  
----@param button number The mouse button index.  
----@return boolean True if the mouse button is down.  
+---Checks if a mouse button is down.
+---@param button number The mouse button index.
+---@return boolean True if the mouse button is down.
 function ImGui.IsMouseDown(button) end
 
----Checks if a mouse button is clicked.  
----@param button number The mouse button index.  
----@param mouse_repeat boolean If the mouse click should repeat.  
----@return boolean True if the mouse button was clicked.  
+---Checks if a mouse button is clicked.
+---@param button number The mouse button index.
+---@param mouse_repeat boolean If the mouse click should repeat.
+---@return boolean True if the mouse button was clicked.
 function ImGui.IsMouseClicked(button, mouse_repeat) end
 
----Checks if a mouse button is clicked.  
----@param button number The mouse button index.  
----@return boolean True if the mouse button was clicked.  
+---Checks if a mouse button is clicked.
+---@param button number The mouse button index.
+---@return boolean True if the mouse button was clicked.
 function ImGui.IsMouseClicked(button) end
 
----Checks if a mouse button is released.  
----@param button number The mouse button index.  
----@return boolean True if the mouse button was released.  
+---Checks if a mouse button is released.
+---@param button number The mouse button index.
+---@return boolean True if the mouse button was released.
 function ImGui.IsMouseReleased(button) end
 
----Returns the position of your mouse.  
----@return Vector2 the position of your mouse.  
+---Returns the position of your mouse.
+---@return Vector2 the position of your mouse.
 function ImGui.GetMousePos() end
 
----Returns the size of the Minecraft window.  
----@return Vector2 the width and height of the window in pixels.  
+---Returns the size of the Minecraft window.
+---@return Vector2 the width and height of the window in pixels.
 function ImGui.GetDisplaySize() end
 
----Returns Minecraft's framerate in floating point numbers.  
----@return number the current framerate.  
-function ImGui.GetFrameRate() end
+---Returns Minecraft's framerate in floating point numbers.
+---@return number the current framerate.
+function ImGui.GetFramerate() end
 
----Returns the time taken to render one frame, in seconds.  
----@return number The delta time  
+---Returns the time taken to render one frame, in seconds.
+---@return number The delta time
 function ImGui.GetDeltaTime() end


### PR DESCRIPTION
Updates the Lua scripting docs/autocomplete from the current `dll-css` scripting bindings.

Latest sync fixes ImGui API drift:
- `ImGui.BeginMenuBar()` instead of duplicate `BeginMainMenuBar()`
- `ImGui.GetFramerate()` casing to match the binding
- documents `ImGui.GetIO()`

Validation: `npm run build` passed.