### PR TITLE
docs: add entity scripting APIs

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -50,6 +50,7 @@ export default defineConfig({
                         { text: "network", link: "/api/client/network.md" }
                     ]},
                     { text: "Game", collapsed: false, items: [
+                        { text: "entity", link: "/api/game/entity.md" },
                         { text: "events", link: "/api/game/events.md" },
                         { text: "player", link: "/api/game/player.md" },
                         { text: "server", link: "/api/game/server.md" },

--- a/api/game/entity.md
+++ b/api/game/entity.md
@@ -1,0 +1,61 @@
+# `Entity` class
+
+
+
+## `Entity:isValid`
+```lua
+function Entity:isValid() end
+```
+Returns true if the entity pointer is present and still valid.
+
+#### Returns
+- boolean: True if the entity is valid.
+
+## `Entity:getTypeId`
+```lua
+function Entity:getTypeId() end
+```
+Returns the entity type identifier, such as "minecraft:zombie".  
+Falls back to an actor type id, alias, or "unknown" when no full identifier is available.
+
+#### Returns
+- string: The entity type identifier.
+
+## `Entity:getName`
+```lua
+function Entity:getName() end
+```
+Returns the entity display name.  
+For players this is the player name; for other entities this is the formatting-stripped nametag.
+
+#### Returns
+- string: The entity name, or an empty string when unavailable.
+
+## `Entity:getOwnerName`
+```lua
+function Entity:getOwnerName() end
+```
+Returns the owning player's name for owned entities such as projectiles or pets.
+
+#### Returns
+- string: The owner name, or an empty string when unavailable.
+
+## `Entity:isVisibleToPlayer`
+```lua
+function Entity:isVisibleToPlayer() end
+```
+Checks whether the entity is inside the local player's view and has a clear block path.
+
+#### Returns
+- boolean: True if the entity is visible to the local player.
+
+## `Entity:distanceToPlayer`
+```lua
+function Entity:distanceToPlayer() end
+```
+Returns the distance from this entity to the local player.
+
+#### Returns
+- number: The distance to the local player, or 0 when unavailable.
+
+Reference: [entity.lua](https://github.com/flarialmc/scripting-wiki/tree/main/autocomplete/game/entity.lua)

--- a/api/game/player.md
+++ b/api/game/player.md
@@ -65,6 +65,18 @@ Returns the player's horizontal movement speed.
 #### Returns
 - number: The player's horizontal speed.
 
+## `player.isTeammate`
+```lua
+function player.isTeammate(playerName) end
+```
+Checks whether another player is on the same team as the local player.
+The lookup matches the player's raw name or formatting-stripped nametag.
+
+#### Parameters
+- `playerName`: string: The player name or visible nametag to check.
+#### Returns
+- boolean: True if the matched player is on your team.
+
 ## `player.health`
 ```lua
 function player.health() end

--- a/api/game/world.md
+++ b/api/game/world.md
@@ -77,4 +77,16 @@ Returns an empty string if the world name isn't available.
 #### Returns
 - string: The world name.
 
+## `world.getEntities`
+```lua
+function world.getEntities(maxDistance) end
+```
+Returns nearby loaded entities around the local player.
+The local player is excluded. Pass 0 to disable the distance filter.
+
+#### Parameters
+- `maxDistance`: number|nil: Maximum distance from the local player. Defaults to 128.
+#### Returns
+- Entity[]: The matching entities.
+
 Reference: [world.lua](https://github.com/flarialmc/scripting-wiki/tree/main/autocomplete/game/world.lua)

--- a/autocomplete/game/entity.lua
+++ b/autocomplete/game/entity.lua
@@ -1,0 +1,30 @@
+---@meta
+
+---@class Entity
+Entity = {}
+
+---Returns true if the entity pointer is present and still valid.
+---@return boolean True if the entity is valid.
+function Entity:isValid() end
+
+---Returns the entity type identifier, such as "minecraft:zombie".
+---Falls back to an actor type id, alias, or "unknown" when no full identifier is available.
+---@return string The entity type identifier.
+function Entity:getTypeId() end
+
+---Returns the entity display name.
+---For players this is the player name; for other entities this is the formatting-stripped nametag.
+---@return string The entity name, or an empty string when unavailable.
+function Entity:getName() end
+
+---Returns the owning player's name for owned entities such as projectiles or pets.
+---@return string The owner name, or an empty string when unavailable.
+function Entity:getOwnerName() end
+
+---Checks whether the entity is inside the local player's view and has a clear block path.
+---@return boolean True if the entity is visible to the local player.
+function Entity:isVisibleToPlayer() end
+
+---Returns the distance from this entity to the local player.
+---@return number The distance to the local player, or 0 when unavailable.
+function Entity:distanceToPlayer() end

--- a/autocomplete/game/player.lua
+++ b/autocomplete/game/player.lua
@@ -36,6 +36,12 @@ function player.velocity() end
 ---@return number The player's horizontal speed.
 function player.speed() end
 
+---Checks whether another player is on the same team as the local player.
+---The lookup matches the player's raw name or formatting-stripped nametag.
+---@param playerName string The player name or visible nametag to check.
+---@return boolean True if the matched player is on your team.
+function player.isTeammate(playerName) end
+
 ---Returns the player's health.
 ---Returns -1 if health isn't available.
 ---@return number health The player's health.

--- a/autocomplete/game/world.lua
+++ b/autocomplete/game/world.lua
@@ -43,3 +43,9 @@ function world.getDimension() end
 ---Returns an empty string if the world name isn't available.
 ---@return string The world name.
 function world.getWorldName() end
+
+---Returns nearby loaded entities around the local player.
+---The local player is excluded. Pass 0 to disable the distance filter.
+---@param maxDistance number|nil Maximum distance from the local player. Defaults to 128.
+---@return Entity[] The matching entities.
+function world.getEntities(maxDistance) end


### PR DESCRIPTION
Updates the scripting docs from recent dll-css scripting commits.

Changes:
- Document player.isTeammate(playerName)
- Add Entity API reference/autocomplete
- Document world.getEntities(maxDistance)
- Add Entity page to the Game sidebar

Validation:
- npm run build